### PR TITLE
Update gitignore

### DIFF
--- a/skeletons/webpack/gitignore
+++ b/skeletons/webpack/gitignore
@@ -47,3 +47,5 @@ node_modules/
 .env
 .env.test
 
+# WebStorm
+.idea/


### PR DESCRIPTION
Webstorms uses a folder named `.idea/` for some IDE settings.