### PR TITLE
Include inherited font for form elements; Improve accessibility for motion-reduced browsers

### DIFF
--- a/skeletons/react/src/components/unlisted/GlobalStyle.tsx
+++ b/skeletons/react/src/components/unlisted/GlobalStyle.tsx
@@ -9,4 +9,26 @@ export default createGlobalStyle`
     line-height: 1.75;
     font-size: 1.25em;
   }
+
+  input,
+  button,
+  textarea,
+  select {
+    font: inherit;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    html:focus-within {
+    scroll-behavior: auto;
+    }
+    
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
 `;

--- a/skeletons/vue/src/styles/layout/_base.scss
+++ b/skeletons/vue/src/styles/layout/_base.scss
@@ -31,3 +31,25 @@ ol {
 img {
   display: block;
 }
+
+input,
+button,
+textarea,
+select {
+  font: inherit;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html:focus-within {
+   scroll-behavior: auto;
+  }
+  
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
Included in this PR:
1. Extended font rules in base styles to include form elements.
2. Added media query to base styles to check for motion-reduction and switch off animations if present.

Why
1. `button`, `select` etc. by default don't share the same font rules as other html elements. There may be cases where we'd want a different font for an `input`, but I'd argue 99 times out of 100 that's not the case.
Inspiration from [CSS-Tricks](https://css-tricks.com/overriding-default-button-styles/) and [Normalize.css](https://github.com/necolas/normalize.css/blob/master/normalize.css).
2. For some users animations can be dizzying and disorientating at best, and induce epileptic fits at worst. We love our animations, but if we want to be serious about putting a11y at the forefront, this is a necessary step.
Inspiration from [a11y-101](https://a11y-101.com/development/reduced-motion#:~:text=On%20a%20Mac%20you%20go,turn%20on%22Reduce%20Motion%22.).