### PR TITLE
Call correct function for monck config

### DIFF
--- a/templates/muban/.storybook/main.cjs
+++ b/templates/muban/.storybook/main.cjs
@@ -45,7 +45,7 @@ module.exports = {
   async managerWebpack(config) {
     if (!ENABLE_MOCK_API_MIDDLEWARE) return config;
 
-    return [config, await (await getConfig()).mocksConfig()];
+    return [config, await (await getConfig()).monckConfig()];
   },
 };
 


### PR DESCRIPTION
The function name for getting the monck config is called `monckConfig` instead of `mockConfig`.