### PR TITLE
plop-scripts: Only add exit listener when executing command

### DIFF
--- a/scripts/plop/src/index.ts
+++ b/scripts/plop/src/index.ts
@@ -25,6 +25,11 @@ export async function plop() {
     compilePlopfile(),
   ] as const);
 
+  process.on('SIGTERM', onExit);
+  process.on('SIGINT', onExit);
+  process.on('exit', onExit);
+  process.on('error', onExit);
+
   const args = process.argv.slice(2);
   const argv = minimist(args);
 
@@ -46,8 +51,3 @@ export async function plop() {
 function onExit() {
   unlinkSync(paths.compiledPlopfile);
 }
-
-process.on('SIGTERM', onExit);
-process.on('SIGINT', onExit);
-process.on('exit', onExit);
-process.on('error', onExit);


### PR DESCRIPTION
It would always add the listeners when this file would be loaded,
but the `onExit` wouldn't be defined, so on any command termination,
these handlers would give errors.