### PR TITLE
Use better supported `&&` to execute multiple commands in postinstall

### DIFF
--- a/core/create-pota/src/package.ts
+++ b/core/create-pota/src/package.ts
@@ -129,7 +129,7 @@ export function cleanupPostInstall(postInstall: string) {
   const rebuilds = postInstall.match(/npm rebuild ([\w\s-]+(&&|;))/gi) ?? [];
 
   if (rebuilds.length === 0) {
-    return postInstall.substring(0, postInstall.length - 1);;
+    return postInstall.substring(0, postInstall.length - 1);
   }
 
   // remove rebuilds from post-install
@@ -153,5 +153,5 @@ export function cleanupPostInstall(postInstall: string) {
       }, [])
       .join(' ');
 
-  return `npm rebuild ${parsedRebuilds} --ignore-scripts=false; ${postInstall}`.replace(/[\s]{2,}/g, " ").trim();
+  return `npm rebuild ${parsedRebuilds} --ignore-scripts=false && ${postInstall}`.replace(/[\s]{2,}/g, " ").trim();
 }

--- a/templates/muban/package.json
+++ b/templates/muban/package.json
@@ -19,7 +19,7 @@
     "fix": "run-s fix:* && npm run format",
     "fix:eslint": "npm run lint:eslint -- --fix",
     "format": "prettier \"**/*.{js,jsx,ts,tsx,scss,md,json}\" --write --loglevel warn",
-    "postinstall": "npm rebuild fsevents; npx patch-package; husky install",
+    "postinstall": "npm rebuild fsevents && npx patch-package && husky install",
     "lint": "run-s lint:*",
     "lint:eslint": "eslint . --ext .ts,.tsx --cache --cache-location node_modules/.cache/.eslintcache",
     "plop": "pota plop",

--- a/templates/next/package.json
+++ b/templates/next/package.json
@@ -17,7 +17,7 @@
     "build": "next build",
     "preview": "next start",
     "typecheck": "tsc --project tsconfig.json --noEmit --noUnusedLocals",
-    "postinstall": "npm rebuild fsevents optipng-bin mozjpeg; npx patch-package; npx husky install;",
+    "postinstall": "npm rebuild fsevents optipng-bin mozjpeg && npx patch-package && npx husky install;",
     "plop": "pota plop",
     "fix": "run-s fix:* && npm run format",
     "fix:eslint": "npm run lint:eslint -- --fix",

--- a/templates/react/package.json
+++ b/templates/react/package.json
@@ -16,7 +16,7 @@
     "build": "pota build",
     "build-storybook": "build-storybook",
     "dev": "pota dev",
-    "postinstall": "npm rebuild fsevents; npx patch-package; npx husky install;",
+    "postinstall": "npm rebuild fsevents && npx patch-package && npx husky install;",
     "plop": "pota plop",
     "start-storybook": "start-storybook -p 9001",
     "test": "jest --config ./test-utils/jest.config.ts",


### PR DESCRIPTION
The `;` delimiter doesn't work on Windows CMD.
The `&&` delimiter works both on CMD and the newest PowerShell, version 7.

So I feel that's the better option to pick.