### PR TITLE
Feature/vite scripts dev mode

### DIFF
--- a/scripts/vite/src/config.ts
+++ b/scripts/vite/src/config.ts
@@ -14,7 +14,7 @@ export class ViteConfig<C extends ViteConfigOptions = ViteConfigOptions> {
   constructor(public readonly options: C) {}
 
   public get isDev() {
-    return process.env.NODE_ENV === 'development';
+    return !process.env.NODE_ENV || process.env.NODE_ENV === 'development';
   }
 
   public get isProd() {

--- a/scripts/vite/src/plugins/inject-entry-tag-plugin.ts
+++ b/scripts/vite/src/plugins/inject-entry-tag-plugin.ts
@@ -10,6 +10,7 @@ export function injectEntryTagPlugin(entryPath: string): Plugin {
           {
             tag: 'script',
             attrs: { type: 'module', src: entryPath },
+            injectTo: 'head',
           },
         ];
       },


### PR DESCRIPTION
**Use dev mode by default when NODE_ENV var is not set**

Otherwise locally you would use production mode when running `npm run dev`, which is unexpected.

After fixing that, I ran into another issue:

**vite-scripts: Change injection point of entry path in HTML**

The default setting, depending on the order of how plugins are
configured, would result in the HMR plugin code being injected AFTER the
entry script. This would mean that component code would execute before
HMR code was set up, and would fail.

Potentially there are 3 options to fix this;
1) change `enforce: 'pre'` to `post` to allow executing after other plugins
2) change the order of plugins in `scripts/react-vite/config` to append the `react-vite` plugin before the super plugins, but that could have other side-effects in the future.
3) change the `injectTo` from `prepend-head` to `head` to make sure it's always injected into other

Here the 3rd option is chosen.