### PR TITLE
Include the main.scss into storybook

### DIFF
--- a/templates/muban/.storybook/preview.js
+++ b/templates/muban/.storybook/preview.js
@@ -1,3 +1,5 @@
+import '../src/styles/main.scss';
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {


### PR DESCRIPTION
Adding the import to our main.scss ensures we get the same global styles on the Storybook build as we do on the dev server.

This resolves #111