### PR TITLE
Add `flattenPath` Option for flexible template resolution

### DIFF
--- a/support/twig-server/README.md
+++ b/support/twig-server/README.md
@@ -87,6 +87,8 @@ Middleware options:
   namespace for your template includes.
 - `extensionPath?: string` - A path to a file that exports an `addExtensions` function to enhance
   the Twig Environment.
+- `flattenPath?: boolean [false]` - Flatten the path of the template files to search in folders with
+  other names than the template id.
 
   ```js
   // the 2nd parameters exposes the 'twing' import,
@@ -120,6 +122,8 @@ Middleware options:
                                                                                         [array] [default: "./templates"]
   -e, --extension-path  A path to a file that exports an `addExtensions` function to enhance the Twig Environment.
                                                                                                                 [string]
+  -f, --flatten-path    Flatten the path of the template files to search in folders with other names than the template i
+                        d.                                                                                     [boolean]
 
 Options:
       --help  Show help                                                                                        [boolean]
@@ -147,9 +151,9 @@ options give issues.
 
 ### Template ID
 
-It expects the component filename and folder name to be the same.
-
-The templateId `atoms/button` will be resolved to `/templates/atoms/button/button.twig`.
+If `flattenPath` is set to `false` (default), it expects the component filename and folder name to be the same, so
+the templateId `atoms/button` will be resolved to `/templates/atoms/button/button.html.twig`. Otherwise it will
+resolve to `/templates/atoms/button.html.twig`.
 
 This server supports three methods of getting the template id. In all examples `component-templates`
 is the `mountPath` option.
@@ -165,7 +169,8 @@ GET /component-templates/atoms/button
 ```
 # will load from disk
 
-/templates/atoms/button/button.twig
+/templates/atoms/button/button.html.twig    # flattenPath = false (default)
+/templates/atoms/button.html.twig           # flattenPath = true
 ```
 
 #### 2. the "templateId" in the query string
@@ -179,7 +184,8 @@ GET /component-templates?templateId=atoms/button
 ```
 # will load from disk
 
-/templates/atoms/button/button.twig
+/templates/atoms/button/button.html.twig    # flattenPath = false (default)
+/templates/atoms/button.html.twig           # flattenPath = true
 ```
 
 #### 3. the "templateId" in the json body
@@ -197,7 +203,8 @@ POST /component-templates
 ```
 # will load from disk
 
-/templates/atoms/button/button.twig
+/templates/atoms/button/button.html.twig    # flattenPath = false (default)
+/templates/atoms/button.html.twig           # flattenPath = true
 ```
 
 ### Template Data

--- a/support/twig-server/example/esm/flat.ts
+++ b/support/twig-server/example/esm/flat.ts
@@ -1,0 +1,13 @@
+import path from 'path';
+import { URL } from 'url';
+import { createServer } from '../../src/index';
+
+createServer({
+  flattenPath: true,
+  templateDir: path.resolve(new URL('.', import.meta.url).pathname, '../templates/all'),
+  useUnixSocket: process.env.NODE_ENV === 'production',
+  extensionPath: path.resolve(
+    new URL('.', import.meta.url).pathname,
+    '../extensions/twig-extensions.cjs',
+  ),
+});

--- a/support/twig-server/example/templates/all/button.html.twig
+++ b/support/twig-server/example/templates/all/button.html.twig
@@ -1,0 +1,7 @@
+<button
+  data-component="button"
+  data-ref="{{ ref }}"
+  class="btn btn-primary"
+>
+  {{ label }}
+</button>

--- a/support/twig-server/example/templates/all/cf-a2-icon.html.twig
+++ b/support/twig-server/example/templates/all/cf-a2-icon.html.twig
@@ -1,0 +1,7 @@
+<span
+  data-component="cf-a2-icon"
+  data-name="{{ name }}"
+  data-ref="{{ ref }}"
+  {# todo: handle both array and string #}
+  class="{{ className }}"
+></span>

--- a/support/twig-server/example/templates/all/toggle-expand.html.twig
+++ b/support/twig-server/example/templates/all/toggle-expand.html.twig
@@ -1,0 +1,14 @@
+<div {{ objectToDataAttributes({ component: 'toggle-expand', ref: ref, isExpanded: isExpanded }) }}>
+  <p>{% include 'cf-a2-icon.html.twig' with { name: 'checkmark' } %}</p>
+  <p>
+    B Lorem ipsum dolor sit amet, consectetur adipisicing elit. Atque consequatur cum laboriosam
+    voluptate voluptatibus. Alias aut autem eligendi perspiciatis provident quae quisquam sapiente
+    sequi, vero voluptatibus. Dolores dolorum exercitationem voluptate.
+  </p>
+  <p>{% include 'button.html.twig' with { label: 'Expand', ref: 'expand-button' } %}</p>
+  <p data-ref="expand-content">
+    Lorem ipsum <strong>dolor</strong> sit <em>amet</em>, consectetur adipisicing elit. Distinctio
+    error incidunt necessitatibus repellendus sint. A, deleniti ducimus ex facere ipsam libero
+    quae quas temporibus voluptas voluptates. Blanditiis consequatur deserunt facere!
+  </p>
+</div>

--- a/support/twig-server/package-lock.json
+++ b/support/twig-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pota/twig-server",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pota/twig-server",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "1.19.0",

--- a/support/twig-server/package.json
+++ b/support/twig-server/package.json
@@ -28,6 +28,7 @@
   "scripts": {
     "dev": "nodemon --ext ts --exec 'tsm' example/esm/index.ts",
     "dev:multi": "nodemon --ext ts --exec 'tsm' example/esm/multi.ts",
+    "dev:flat": "nodemon --ext ts --exec 'tsm' example/esm/flat.ts",
     "dev:cjs": "nodemon --ext ts --exec 'tsm' example/cjs/index.cjs",
     "dev:cli": "tsc -p tsconfig.build.json --watch",
     "build": "tsc -p tsconfig.build.json",

--- a/support/twig-server/src/cli.ts
+++ b/support/twig-server/src/cli.ts
@@ -13,6 +13,7 @@ yargs(hideBin(process.argv))
     socketPath: string;
     templateDir: Array<string>;
     extensionPath: string;
+    flattenPath: boolean;
   }>(
     ['$0', 'server'],
     'Start a twig render server',
@@ -94,8 +95,15 @@ yargs(hideBin(process.argv))
       'Whether to enable cors for the created server, so it accepts requests from other origins.',
     type: 'boolean',
   })
+  .option('f', {
+    alias: 'flatten-path',
+    default: DEFAULT_SERVER_OPTIONS.flattenPath,
+    describe:
+      'Flatten the path of the template files to search in folders with other names than the template id.',
+    type: 'boolean',
+  })
   .group(['mount-path', 'host', 'port', 'unix-socket', 'socket-path', 'cors'], 'Server options:')
-  .group(['template-dir', 'extension-path'], 'Middleware options:')
+  .group(['template-dir', 'extension-path', 'flatten-path'], 'Middleware options:')
   .help()
   .epilogue(
     'For more information about the parameters, please visit https://github.com/mediamonks/pota',

--- a/support/twig-server/src/createServer.ts
+++ b/support/twig-server/src/createServer.ts
@@ -20,6 +20,7 @@ export const DEFAULT_SERVER_OPTIONS: Required<Omit<ServerOptions, 'ignore' | 'ex
   socketPath: resolve(process.cwd(), './socket'),
   templateDir: './templates',
   cors: false,
+  flattenPath: false,
 };
 
 export function createServer(serverOptions: ServerOptions = {}): Express {

--- a/support/twig-server/src/getTwigMiddleware.ts
+++ b/support/twig-server/src/getTwigMiddleware.ts
@@ -73,7 +73,9 @@ export function getTwigMiddleware(
 
     const templateId = req.body?.templateId ?? req.query.templateId ?? req.path.substring(1);
     const componentName = basename(templateId);
-    const dirName = dirname(templateId);
+    const templatePath = options.flattenPath
+      ? join(dirname(templateId), `${componentName}.html.twig`)
+      : join(dirname(templateId), componentName, `${componentName}.html.twig`);
 
     try {
       const templateData =
@@ -82,10 +84,7 @@ export function getTwigMiddleware(
           ? JSON.parse(req.query.templateData)
           : req.query);
 
-      const result = await env.render(
-        join(dirName, componentName, `${componentName}.html.twig`),
-        templateData,
-      );
+      const result = await env.render(templatePath, templateData);
       res.send(result);
     } catch (e: any) {
       if (e.message.includes('Unable to find template')) {

--- a/support/twig-server/src/types.ts
+++ b/support/twig-server/src/types.ts
@@ -1,5 +1,6 @@
 export type TemplateOptions = {
   extensionPath?: string;
+  flattenPath?: boolean;
 };
 
 export type TemplateDirConfig =


### PR DESCRIPTION
### Add `flattenPath` Option for flexible template resolution

This PR introduces a new `flattenPath` option to `createServer` and `getTwigMiddleware`, allowing more flexible template path resolution.

#### Motivation

Previously, template resolution required the template folder and filename to match the component ID, e.g., `twig/button/button.html.twig`. This limited the ability to organize or reuse templates, especially when multiple templates exist in the same directory.

#### What’s Changed

- **New Option:**  
  - `flattenPath: false` (default): Resolves to `twig/button/button.html.twig` (folder and filename must match).
  - `flattenPath: true`: Resolves to `twig/button.html.twig` (filename only, allowing multiple templates per folder).

This is particularly useful for scenarios like Drupal, where templates are resolved at the same level:

```twig
{% include 'heading.html.twig' %}
{% include 'button.html.twig' %}
{% include 'image.html.twig' %}
```

#### Example

A sample is available in twig-server:

```sh
cd support/twig-server
npm install
npm run dev:flat
```

You can then access any template in `support/twig-server/templates/all` via 
**http://localhost:9003/component-templates**